### PR TITLE
update to 1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## History
 
+### 1.6.5  (Oct 4, 2015) - Nolan O'Brien
+
+- Fix bug in Apple Encoder/Decoder
+- Add convenience NSInputStream for compressed streams (could be optimized further)
+
 ### 1.6.0  (Sep 26, 2015) - Nolan O'Brien
 
 - Rename NOZCompressionEncoder/Decoder to NOZEncoder/Decoder

--- a/Extra/NOZXAppleCompressionCoder.m
+++ b/Extra/NOZXAppleCompressionCoder.m
@@ -223,13 +223,17 @@
         }
         context.compressedDataPosition += oldDstSize - stream->dst_size;
 
-        if (stream->dst_size == 0) {
-            if (!context.flushCallback(self, context, context.compressedDataBuffer, context.compressedDataPosition)) {
-                success = NO;
+        if (stream->dst_size == 0 || (final && stream->src_size == 0)) {
+            if (context.compressedDataPosition > 0) {
+                if (!context.flushCallback(self, context, context.compressedDataBuffer, context.compressedDataPosition)) {
+                    success = NO;
+                }
+                context.compressedDataPosition = 0;
+                stream->dst_size = context.compressedDataBufferSize;
+                stream->dst_ptr = context.compressedDataBuffer;
+            } else if (final && stream->src_size == 0 && COMPRESSION_STATUS_OK == status) {
+                status = COMPRESSION_STATUS_END;
             }
-            context.compressedDataPosition = 0;
-            stream->dst_size = context.compressedDataBufferSize;
-            stream->dst_ptr = context.compressedDataBuffer;
         }
 
         if (COMPRESSION_STATUS_END == status) {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Alternatively you may use one of the following dependency managers:
 Add _ZipUtilities_ to your `Podfile`
 
 ```ruby
-pod 'ZipUtilities', '~> 1.6.0'
+pod 'ZipUtilities', '~> 1.6.5'
 ```
 
 #### Carthage

--- a/ZipUtilities.podspec
+++ b/ZipUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ZipUtilities"
-  s.version      = "1.6.0"
+  s.version      = "1.6.5"
   s.summary      = "Zip Archiving, Unarchiving and Utilities in Objective-C"
   s.description  = <<-DESC
 					ZipUtilities, prefixed with NOZ for Nolan O'Brien ZipUtilities, is a library of zipping and unzipping utilities for iOS and Mac OS X.

--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -55,6 +55,12 @@
 		1CCAC7991B890FAD004AD418 /* NOZCompression.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CCAC7971B890FAD004AD418 /* NOZCompression.m */; };
 		1CCAC79B1B8997F4004AD418 /* NOZDeflateCoders.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CCAC79A1B8997F4004AD418 /* NOZDeflateCoders.m */; };
 		1CCAC79D1B899804004AD418 /* NOZRawCoders.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CCAC79C1B899804004AD418 /* NOZRawCoders.m */; };
+		1CD441BD1BBCDDA500F40FAB /* NSStream+NOZAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CD441BB1BBCDDA500F40FAB /* NSStream+NOZAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1CD441BE1BBCDDA500F40FAB /* NSStream+NOZAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CD441BB1BBCDDA500F40FAB /* NSStream+NOZAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1CD441BF1BBCDDA500F40FAB /* NSStream+NOZAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CD441BB1BBCDDA500F40FAB /* NSStream+NOZAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1CD441C01BBCDDA500F40FAB /* NSStream+NOZAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CD441BC1BBCDDA500F40FAB /* NSStream+NOZAdditions.m */; settings = {ASSET_TAGS = (); }; };
+		1CD441C11BBCDDA500F40FAB /* NSStream+NOZAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CD441BC1BBCDDA500F40FAB /* NSStream+NOZAdditions.m */; settings = {ASSET_TAGS = (); }; };
+		1CD441C21BBCDDA500F40FAB /* NSStream+NOZAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CD441BC1BBCDDA500F40FAB /* NSStream+NOZAdditions.m */; settings = {ASSET_TAGS = (); }; };
 		1CD9BAB41B757A38000B93C4 /* Aesop.txt in Resources */ = {isa = PBXBuildFile; fileRef = 1CD9BAB31B757A38000B93C4 /* Aesop.txt */; };
 		1CD9BAB61B757E3F000B93C4 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CD9BAB51B757E3F000B93C4 /* libz.dylib */; };
 		1CD9BABC1B75B419000B93C4 /* Directory.zip in Resources */ = {isa = PBXBuildFile; fileRef = 1CD9BAB81B75B419000B93C4 /* Directory.zip */; };
@@ -210,6 +216,8 @@
 		1CCAC7971B890FAD004AD418 /* NOZCompression.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NOZCompression.m; sourceTree = "<group>"; };
 		1CCAC79A1B8997F4004AD418 /* NOZDeflateCoders.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NOZDeflateCoders.m; sourceTree = "<group>"; };
 		1CCAC79C1B899804004AD418 /* NOZRawCoders.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NOZRawCoders.m; sourceTree = "<group>"; };
+		1CD441BB1BBCDDA500F40FAB /* NSStream+NOZAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSStream+NOZAdditions.h"; sourceTree = "<group>"; };
+		1CD441BC1BBCDDA500F40FAB /* NSStream+NOZAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSStream+NOZAdditions.m"; sourceTree = "<group>"; };
 		1CD9BAB31B757A38000B93C4 /* Aesop.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Aesop.txt; sourceTree = "<group>"; };
 		1CD9BAB51B757E3F000B93C4 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		1CD9BAB81B75B419000B93C4 /* Directory.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = Directory.zip; sourceTree = "<group>"; };
@@ -349,6 +357,8 @@
 				1C05422A1B7BDD97007CE7BA /* NOZZipper.m */,
 				1C7634301BB6455700BBFECF /* NSData+NOZAdditions.h */,
 				1C7634311BB6455700BBFECF /* NSData+NOZAdditions.m */,
+				1CD441BB1BBCDDA500F40FAB /* NSStream+NOZAdditions.h */,
+				1CD441BC1BBCDDA500F40FAB /* NSStream+NOZAdditions.m */,
 				1C6BF7AF1B74769400969629 /* Project */,
 			);
 			path = ZipUtilities;
@@ -408,9 +418,9 @@
 		4623A8A81B9A8A6B00A56535 /* Framework */ = {
 			isa = PBXGroup;
 			children = (
-				4623A8321B9A828A00A56535 /* ZipUtilities.h */,
 				4623A8311B9A828A00A56535 /* Info.plist */,
 				4623A8AB1B9A8CA400A56535 /* OSX-Info.plist */,
+				4623A8321B9A828A00A56535 /* ZipUtilities.h */,
 			);
 			name = Framework;
 			sourceTree = "<group>";
@@ -447,6 +457,7 @@
 				1C7634321BB6455700BBFECF /* NSData+NOZAdditions.h in Headers */,
 				1C6BF7951B740AA400969629 /* NOZCompress.h in Headers */,
 				1C6BF7961B740AA400969629 /* NOZDecompress.h in Headers */,
+				1CD441BD1BBCDDA500F40FAB /* NSStream+NOZAdditions.h in Headers */,
 				1C32237A1B77BE9F00DC0A33 /* NOZError.h in Headers */,
 				1C6BF7B41B7476BB00969629 /* NOZ_Project.h in Headers */,
 				1CF2F7EE1B87ABE9005E7C77 /* NOZUtils_Project.h in Headers */,
@@ -462,6 +473,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1CD441BE1BBCDDA500F40FAB /* NSStream+NOZAdditions.h in Headers */,
 				4623A88F1B9A83FE00A56535 /* NOZ_Project.h in Headers */,
 				4623A8831B9A83E200A56535 /* NOZUtils.h in Headers */,
 				4623A8871B9A83E900A56535 /* NOZZipEntry.h in Headers */,
@@ -484,6 +496,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1CD441BF1BBCDDA500F40FAB /* NSStream+NOZAdditions.h in Headers */,
 				4623A8901B9A83FE00A56535 /* NOZ_Project.h in Headers */,
 				4623A8841B9A83E300A56535 /* NOZUtils.h in Headers */,
 				4623A8881B9A83EA00A56535 /* NOZZipEntry.h in Headers */,
@@ -728,6 +741,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1CCAC7991B890FAD004AD418 /* NOZCompression.m in Sources */,
+				1CD441C01BBCDDA500F40FAB /* NSStream+NOZAdditions.m in Sources */,
 				1C3223831B780CC500DC0A33 /* NOZSyncStepOperation.m in Sources */,
 				1CCAC79D1B899804004AD418 /* NOZRawCoders.m in Sources */,
 				1C32237B1B77BE9F00DC0A33 /* NOZError.m in Sources */,
@@ -759,6 +773,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4623A8651B9A83AE00A56535 /* NOZ_Project.m in Sources */,
+				1CD441C11BBCDDA500F40FAB /* NSStream+NOZAdditions.m in Sources */,
 				4623A8731B9A83C900A56535 /* NOZDeflateCoders.m in Sources */,
 				4623A87D1B9A83D900A56535 /* NOZSyncStepOperation.m in Sources */,
 				4623A8771B9A83D000A56535 /* NOZError.m in Sources */,
@@ -790,6 +805,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4623A8661B9A83AF00A56535 /* NOZ_Project.m in Sources */,
+				1CD441C21BBCDDA500F40FAB /* NSStream+NOZAdditions.m in Sources */,
 				4623A8741B9A83CA00A56535 /* NOZDeflateCoders.m in Sources */,
 				4623A87E1B9A83D900A56535 /* NOZSyncStepOperation.m in Sources */,
 				4623A8781B9A83D000A56535 /* NOZError.m in Sources */,

--- a/ZipUtilities/Info.plist
+++ b/ZipUtilities/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ZipUtilities/NSStream+NOZAdditions.h
+++ b/ZipUtilities/NSStream+NOZAdditions.h
@@ -1,0 +1,49 @@
+//
+//  NSStream+NOZAdditions.h
+//  ZipUtilities
+//
+//  Created by Nolan O'Brien on 9/30/15.
+//  Copyright © 2015 NSProgrammer. All rights reserved.
+//
+
+@import Foundation;
+
+#import "NOZCompression.h"
+
+@protocol NOZEncoder;
+@protocol NOZDecoder;
+
+/**
+ Category for __ZipUtilities__ specific convenience methods
+ */
+@interface NSInputStream (NOZAdditions)
+
+/**
+ Create a stream that compresses it's bytes as they are read.  Useful for something like an `NSURLConnection`'s `NSURLRequest` or an `NSURLSessionUploadTask` that provide an `NSInputStream`.
+ @param stream The uncompressed `NSInputStream` to wrap
+ @param encoder The encoder to use for compressing (often best to use `NOZEncoderForCompressionMethod` to get an encoder)
+ @param compressionLevel The level at which to compress (if supported by the _encoder_).
+ @return an `NSInputStream` that compressed it's wrapped _stream_ as bytes are read.
+ NOTE: The implementation of the wrapping `NSInputStream` could probably be further optimized.
+ */
++ (nonnull NSInputStream *)noz_compressedInputStream:(nonnull NSInputStream *)stream
+                                         withEncoder:(nonnull id<NOZEncoder>)encoder
+                                    compressionLevel:(NOZCompressionLevel)compressionLevel;
+
+@end
+
+/**
+ Category for __ZipUtilities__ specific convenience methods
+ */
+@interface NSStream (NOZAdditions)
+
+/**
+ Convenience method to acquire a pair of bount `NSInputStream` and `NSOutputStream` streams.
+ Code comes directly from Apple sample code:
+ https://developer.apple.com/library/ios/samplecode/SimpleURLConnections/Listings/PostController_m.html
+ */
++ (void)noz_createBoundInputStream:(NSInputStream * __nonnull * __nullable)inputStreamPtr
+                      outputStream:(NSOutputStream * __nonnull * __nullable)outputStreamPtr
+                        bufferSize:(NSUInteger)bufferSize;
+
+@end

--- a/ZipUtilities/NSStream+NOZAdditions.m
+++ b/ZipUtilities/NSStream+NOZAdditions.m
@@ -1,0 +1,376 @@
+//
+//  NSStream+NOZAdditions.m
+//  ZipUtilities
+//
+//  Created by Nolan O'Brien on 9/30/15.
+//  Copyright © 2015 NSProgrammer. All rights reserved.
+//
+
+#include <sys/socket.h>
+
+#import "NSStream+NOZAdditions.h"
+#import "NOZ_Project.h"
+#import "NOZEncoder.h"
+#import "NOZError.h"
+
+typedef void (*StreamCreateBoundPairFunc)(CFAllocatorRef,
+                                          CFReadStreamRef *,
+                                          CFWriteStreamRef *,
+                                          CFIndex);
+static void NOZStreamCreateBoundPairCompat(CFAllocatorRef       alloc,
+                                           CFReadStreamRef *    readStreamPtr,
+                                           CFWriteStreamRef *   writeStreamPtr,
+                                           CFIndex              transferBufferSize);
+
+@interface NOZEncodingInputStream : NSInputStream <NSStreamDelegate>
+
+- (nonnull instancetype)initWithInputStream:(nonnull NSInputStream *)stream
+                                    encoder:(nonnull id<NOZEncoder>)encoder
+                           compressionLevel:(NOZCompressionLevel)compressionLevel NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithData:(nonnull NSData *)data NS_UNAVAILABLE;
+- (nullable instancetype)initWithURL:(nonnull NSURL *)url NS_UNAVAILABLE;
+
+@end
+
+@implementation NSInputStream (NOZAdditions)
+
++ (nonnull NSInputStream *)noz_compressedInputStream:(nonnull NSInputStream *)stream
+                                         withEncoder:(nonnull id<NOZEncoder>)encoder
+                                    compressionLevel:(NOZCompressionLevel)compressionLevel
+{
+    return [[NOZEncodingInputStream alloc] initWithInputStream:stream encoder:encoder compressionLevel:compressionLevel];
+}
+
+@end
+
+@implementation NOZEncodingInputStream
+{
+    NSInputStream *_stream;
+    id<NOZEncoder> _encoder;
+    id<NOZEncoderContext> _encoderContext;
+    NOZCompressionLevel _compressionLevel;
+
+    NSError *_encoderError;
+
+    NSMutableData *_excessData;
+    size_t _excessDataRead;
+
+    Byte *_currentReadBuffer;
+    size_t _currentReadBufferLength;
+    size_t _currentReadBufferUsed;
+
+    CFReadStreamClientCallBack _copiedCallback;
+    CFStreamClientContext _copiedContext;
+    CFOptionFlags _requestedEvents;
+}
+
+- (nonnull instancetype)initWithInputStream:(nonnull NSInputStream *)stream
+                                    encoder:(nonnull id<NOZEncoder>)encoder
+                           compressionLevel:(NOZCompressionLevel)compressionLevel
+{
+    static NSData *sData = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        char c = 0;
+        sData = [NSData dataWithBytes:&c length:1];
+    });
+
+    if (self = [super initWithData:sData]) {
+        _stream = stream;
+        _encoder = encoder;
+        _compressionLevel = compressionLevel;
+        _stream.delegate = self;
+    }
+
+    return self;
+}
+
+- (void)dealloc
+{
+    _stream.delegate = nil;
+    _requestedEvents = kCFStreamEventNone;
+    if (_copiedCallback) {
+        _copiedCallback = NULL;
+        bzero(&_copiedContext, sizeof(CFStreamClientContext));
+    }
+}
+
+- (void)open
+{
+    [_stream open];
+
+    _encoderContext = [_encoder createContextWithBitFlags:0
+                                         compressionLevel:_compressionLevel
+                                            flushCallback:^BOOL(id<NOZEncoder> encoder, id<NOZEncoderContext> context, const Byte *bufferToFlush, size_t length) {
+                                                return [self private_flushBytes:bufferToFlush length:length];
+                                            }];
+
+    if (![_encoder initializeEncoderContext:_encoderContext]) {
+        _encoderError = NOZErrorCreate(NOZErrorCodeZipFailedToCompressEntry, nil);
+        _encoder = nil;
+    }
+}
+
+- (void)close
+{
+    _encoderContext = nil;
+    _excessData = nil;
+
+    [_stream close];
+}
+
+- (NSStreamStatus)streamStatus
+{
+    return _encoderError ? NSStreamStatusError : _stream.streamStatus;
+}
+
+- (NSError *)streamError
+{
+    return _encoderError ?: _stream.streamError;
+}
+
+- (BOOL)private_flushBytes:(const Byte *)bufferToFlush length:(size_t)length
+{
+    size_t bytesFlushed = 0;
+    if (_currentReadBufferUsed < _currentReadBufferLength) {
+        bytesFlushed = MIN(length, (_currentReadBufferLength - _currentReadBufferUsed));
+        memcpy(_currentReadBuffer, bufferToFlush, bytesFlushed);
+        _currentReadBufferUsed += bytesFlushed;
+    }
+
+    if (bytesFlushed < length) {
+        length -= bytesFlushed;
+        bufferToFlush += bytesFlushed;
+
+        if (!_excessData) {
+            _excessData = [NSMutableData dataWithBytes:bufferToFlush length:length];
+            _excessDataRead = 0;
+        } else {
+            [_excessData appendBytes:bufferToFlush length:length];
+        }
+    }
+
+    return YES;
+}
+
+- (NSInteger)read:(uint8_t *)buffer maxLength:(NSUInteger)len
+{
+    if (len == 0) {
+        _encoderError = NOZErrorCreate(NOZErrorCodeZipFailedToCompressEntry, @{ @"reason" : @"cannot read with zero length buffer" });
+    }
+
+    if (self.streamError) {
+        return -1;
+    }
+
+    size_t excessBytesAvailable = _excessData.length - _excessDataRead;
+    if (excessBytesAvailable > 0) {
+        size_t bytesToRead = MIN(len, excessBytesAvailable);
+        memcpy(buffer, _excessData.bytes + _excessDataRead, bytesToRead);
+        _excessDataRead += bytesToRead;
+        if (_excessDataRead == _excessData.length) {
+            _excessData = nil;
+            _excessDataRead = 0;
+        }
+        return (NSInteger)bytesToRead;
+    }
+
+    _currentReadBuffer = buffer;
+    _currentReadBufferLength = len;
+    _currentReadBufferUsed = 0;
+    noz_defer(^{
+        _currentReadBufferUsed = 0;
+        _currentReadBufferLength = 0;
+        _currentReadBuffer = NULL;
+    });
+
+    const size_t intermediateBufferSize = len;
+    uint8_t intermediateBuffer[intermediateBufferSize];
+    NSInteger rawBytesRead = 0;
+
+    do {
+        rawBytesRead = [_stream read:intermediateBuffer maxLength:intermediateBufferSize];
+
+        if (rawBytesRead < 0) {
+            return rawBytesRead;
+        } else if (rawBytesRead == 0) {
+            [_encoder finalizeEncoderContext:_encoderContext];
+            break;
+        }
+
+        if (![_encoder encodeBytes:intermediateBuffer length:(size_t)rawBytesRead context:_encoderContext]) {
+            _encoderError = NOZErrorCreate(NOZErrorCodeZipFailedToCompressEntry, nil);
+            return -1;
+        }
+    } while (rawBytesRead > 0 && _currentReadBufferUsed < _currentReadBufferLength);
+
+    NSInteger returnValue = (NSInteger)_currentReadBufferUsed;
+    return returnValue;
+}
+
+- (BOOL)getBuffer:(uint8_t * __nullable * __nonnull)buffer length:(NSUInteger *)len
+{
+    return NO;
+}
+
+- (BOOL)hasBytesAvailable
+{
+    return [_stream hasBytesAvailable] || ((_excessData.length - _excessDataRead) > 0);
+}
+
+#pragma mark Delegate
+
+- (void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode
+{
+    NSAssert(aStream == _stream, @"Got an unexpected stream calling stream:handleEvent:");
+    if (aStream != _stream) {
+        return;
+    }
+
+    CFStreamEventType cfEventCode = (CFStreamEventType)eventCode;
+    if ((_requestedEvents & cfEventCode) && _copiedCallback) {
+        _copiedCallback((__bridge CFReadStreamRef)self, cfEventCode, _copiedContext.info);
+    }
+
+    id<NSStreamDelegate> delegate = self.delegate;
+    if ([delegate respondsToSelector:@selector(stream:handleEvent:)]) {
+        [delegate stream:aStream handleEvent:eventCode];
+    }
+}
+
+#pragma mark Undocumented CFReadStream methods
+
+- (void)_scheduleInCFRunLoop:(CFRunLoopRef)aRunLoop forMode:(CFStringRef)aMode
+{
+
+    CFReadStreamScheduleWithRunLoop((CFReadStreamRef)_stream, aRunLoop, aMode);
+}
+
+- (BOOL)_setCFClientFlags:(CFOptionFlags)inFlags
+                 callback:(CFReadStreamClientCallBack)inCallback
+                  context:(CFStreamClientContext *)inContext
+{
+
+    if (inCallback != NULL) {
+        _requestedEvents = inFlags;
+        _copiedCallback = inCallback;
+        memcpy(&_copiedContext, inContext, sizeof(CFStreamClientContext));
+
+        if (_copiedContext.info && _copiedContext.retain) {
+            _copiedContext.retain(_copiedContext.info);
+        }
+    } else {
+        _requestedEvents = kCFStreamEventNone;
+        _copiedCallback = NULL;
+        if (_copiedContext.info && _copiedContext.release) {
+            _copiedContext.release(_copiedContext.info);
+        }
+
+        memset(&_copiedContext, 0, sizeof(CFStreamClientContext));
+    }
+
+    return YES;
+}
+
+- (void)_unscheduleFromCFRunLoop:(CFRunLoopRef)aRunLoop forMode:(CFStringRef)aMode
+{
+    CFReadStreamUnscheduleFromRunLoop((CFReadStreamRef)_stream, aRunLoop, aMode);
+}
+
+@end
+
+@implementation NSStream (NOZAdditions)
+
++ (void)noz_createBoundInputStream:(NSInputStream **)inputStreamPtr
+                      outputStream:(NSOutputStream **)outputStreamPtr
+                        bufferSize:(NSUInteger)bufferSize
+{
+    CFReadStreamRef     readStream;
+    CFWriteStreamRef    writeStream;
+
+    assert( (inputStreamPtr != NULL) || (outputStreamPtr != NULL) );
+
+    readStream = NULL;
+    writeStream = NULL;
+
+    // there is a bug in CFStreamCreateBoundPair prior to iOS 5 / Mac OS X 10.7
+    const BOOL isCFStreamCreateBoundPairSafe = ((&NSStreamNetworkServiceTypeBackground) != NULL);
+    StreamCreateBoundPairFunc createBoundPair = (isCFStreamCreateBoundPairSafe) ? CFStreamCreateBoundPair : NOZStreamCreateBoundPairCompat;
+
+    createBoundPair(NULL,
+                    ((inputStreamPtr  != nil) ? &readStream : NULL),
+                    ((outputStreamPtr != nil) ? &writeStream : NULL),
+                    (CFIndex) bufferSize);
+
+    if (inputStreamPtr != NULL) {
+        *inputStreamPtr  = CFBridgingRelease(readStream);
+    }
+    if (outputStreamPtr != NULL) {
+        *outputStreamPtr = CFBridgingRelease(writeStream);
+    }
+}
+
+@end
+
+static void NOZStreamCreateBoundPairCompat(CFAllocatorRef       alloc,
+                                           CFReadStreamRef *    readStreamPtr,
+                                           CFWriteStreamRef *   writeStreamPtr,
+                                           CFIndex              transferBufferSize)
+// This is a drop-in replacement for CFStreamCreateBoundPair that is necessary because that
+// code is broken on iOS versions prior to iOS 5.0 <rdar://problem/7027394> <rdar://problem/7027406>.
+// This emulates a bound pair by creating a pair of UNIX domain sockets and wrapper each end in a
+// CFSocketStream.  This won't give great performance, but it doesn't crash!
+{
+#pragma unused(transferBufferSize)
+    int                 err;
+    Boolean             success;
+    CFReadStreamRef     readStream;
+    CFWriteStreamRef    writeStream;
+    int                 fds[2];
+
+    assert(readStreamPtr != NULL);
+    assert(writeStreamPtr != NULL);
+
+    readStream = NULL;
+    writeStream = NULL;
+
+    // Create the UNIX domain socket pair.
+
+    err = socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+    if (err == 0) {
+        CFStreamCreatePairWithSocket(alloc, fds[0], &readStream,  NULL);
+        CFStreamCreatePairWithSocket(alloc, fds[1], NULL, &writeStream);
+
+        // If we failed to create one of the streams, ignore them both.
+
+        if ( (readStream == NULL) || (writeStream == NULL) ) {
+            if (readStream != NULL) {
+                CFRelease(readStream);
+                readStream = NULL;
+            }
+            if (writeStream != NULL) {
+                CFRelease(writeStream);
+                writeStream = NULL;
+            }
+        }
+        assert( (readStream == NULL) == (writeStream == NULL) );
+
+        // Make sure that the sockets get closed (by us in the case of an error,
+        // or by the stream if we managed to create them successfull).
+
+        if (readStream == NULL) {
+            err = close(fds[0]);
+            assert(err == 0);
+            err = close(fds[1]);
+            assert(err == 0);
+        } else {
+            success = CFReadStreamSetProperty(readStream, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanTrue);
+            assert(success);
+            success = CFWriteStreamSetProperty(writeStream, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanTrue);
+            assert(success);
+        }
+    }
+    
+    *readStreamPtr = readStream;
+    *writeStreamPtr = writeStream;
+}

--- a/ZipUtilities/NSStream+NOZAdditions.m
+++ b/ZipUtilities/NSStream+NOZAdditions.m
@@ -64,18 +64,20 @@ static void NOZStreamCreateBoundPairCompat(CFAllocatorRef       alloc,
     CFOptionFlags _requestedEvents;
 }
 
+/*
+ NSInputStreams MUST call [super init] when subclassing (will crash with unrecognized selector before iOS 9).
+ But there are designated initializers making warnings show.
+ Suppress the warnings and get things working again without complaint.
+ */
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-designated-initializers"
+
 - (nonnull instancetype)initWithInputStream:(nonnull NSInputStream *)stream
                                     encoder:(nonnull id<NOZEncoder>)encoder
                            compressionLevel:(NOZCompressionLevel)compressionLevel
 {
-    static NSData *sData = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        char c = 0;
-        sData = [NSData dataWithBytes:&c length:1];
-    });
-
-    if (self = [super initWithData:sData]) {
+    if (self = [super init]) {
         _stream = stream;
         _encoder = encoder;
         _compressionLevel = compressionLevel;
@@ -84,6 +86,8 @@ static void NOZStreamCreateBoundPairCompat(CFAllocatorRef       alloc,
 
     return self;
 }
+
+#pragma clang diagnostic pop
 
 - (void)dealloc
 {

--- a/ZipUtilities/OSX-Info.plist
+++ b/ZipUtilities/OSX-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ZipUtilities/ZipUtilities.h
+++ b/ZipUtilities/ZipUtilities.h
@@ -48,3 +48,4 @@ FOUNDATION_EXPORT const unsigned char ZipUtilitiesVersionString[];
 #import "NOZZipper.h"
 
 #import "NSData+NOZAdditions.h"
+#import "NSStream+NOZAdditions.h"

--- a/ZipUtilitiesTests/NOZXAppleCompressionCoderTests.m
+++ b/ZipUtilitiesTests/NOZXAppleCompressionCoderTests.m
@@ -105,7 +105,7 @@
     [[NSFileManager defaultManager] removeItemAtPath:zipDirectory error:NULL];
 }
 
-- (void)runDataCodingTest:(NOZCompressionMethod)method
+- (void)runCategoryCodingTest:(NOZCompressionMethod)method
 {
     NSString *sourceFile = [[NSBundle bundleForClass:[self class]] pathForResource:@"Aesop" ofType:@"txt"];
     NSData *sourceData = [NSData dataWithContentsOfFile:sourceFile];
@@ -116,29 +116,55 @@
     id<NOZDecoder> decoder = NOZDecoderForCompressionMethod(method);
     BOOL isRaw = NOZCompressionMethodNone == method;
 
-    compressedData = [sourceData noz_dataByCompressing:encoder
-                                      compressionLevel:NOZCompressionLevelMax];
-    if (encoder) {
-        XCTAssertNotNil(compressedData);
-        if (!isRaw) {
-            XCTAssertLessThan(compressedData.length, sourceData.length);
-            XCTAssertNotEqualObjects(compressedData, sourceData);
+    for (NSUInteger i = 0; i < 2; i++) {
+        if (i == 0) {
+            compressedData = [sourceData noz_dataByCompressing:encoder
+                                              compressionLevel:NOZCompressionLevelMax];
         } else {
-            XCTAssertEqual(compressedData.length, sourceData.length);
-            XCTAssertEqualObjects(compressedData, sourceData);
+            NSInputStream *sourceStream = (i == 1) ? [NSInputStream inputStreamWithFileAtPath:sourceFile] : [NSInputStream inputStreamWithData:sourceData];
+            sourceStream = [NSInputStream noz_compressedInputStream:sourceStream withEncoder:encoder compressionLevel:NOZCompressionLevelMax];
+
+            const size_t bufferSize = NSPageSize();
+            Byte buffer[bufferSize];
+            NSMutableData *compressedDataM = [NSMutableData data];
+
+            [sourceStream open];
+            NSInteger bytesRead = 1;
+            while (sourceStream.hasBytesAvailable && bytesRead > 0) {
+                bytesRead = [sourceStream read:buffer maxLength:bufferSize];
+                if (bytesRead > 0) {
+                    [compressedDataM appendBytes:buffer length:(NSUInteger)bytesRead];
+                }
+            }
+            [sourceStream close];
+
+            XCTAssertFalse(sourceStream.hasBytesAvailable);
+            XCTAssertGreaterThan(compressedDataM.length, (NSUInteger)0);
+            compressedData = (!sourceStream.hasBytesAvailable && compressedDataM.length > 0) ? [compressedDataM copy] : nil;
         }
 
-        decompressedData = [compressedData noz_dataByDecompressing:decoder];
+        if (encoder) {
+            XCTAssertNotNil(compressedData);
+            if (!isRaw) {
+                XCTAssertLessThan(compressedData.length, sourceData.length);
+                XCTAssertNotEqualObjects(compressedData, sourceData);
+            } else {
+                XCTAssertEqual(compressedData.length, sourceData.length);
+                XCTAssertEqualObjects(compressedData, sourceData);
+            }
 
-        if (decoder) {
-            XCTAssertNotNil(decompressedData);
-            XCTAssertEqual(decompressedData.length, sourceData.length);
-            XCTAssertEqualObjects(decompressedData, sourceData);
+            decompressedData = [compressedData noz_dataByDecompressing:decoder];
+
+            if (decoder) {
+                XCTAssertNotNil(decompressedData);
+                XCTAssertEqual(decompressedData.length, sourceData.length);
+                XCTAssertEqualObjects(decompressedData, sourceData);
+            } else {
+                XCTAssertNil(decompressedData);
+            }
         } else {
-            XCTAssertNil(decompressedData);
+            XCTAssertNil(compressedData);
         }
-    } else {
-        XCTAssertNil(compressedData);
     }
 }
 
@@ -154,7 +180,7 @@
     NOZUpdateCompressionMethodDecoder(NOZCompressionMethodDeflate, [NOZXAppleCompressionCoder decoderWithAlgorithm:COMPRESSION_ZLIB]);
 
     [self runCodingWithMethod:NOZCompressionMethodDeflate];
-    [self runDataCodingTest:NOZCompressionMethodDeflate];
+    [self runCategoryCodingTest:NOZCompressionMethodDeflate];
 
     NOZUpdateCompressionMethodEncoder(NOZCompressionMethodDeflate, originalEncoder);
     NOZUpdateCompressionMethodDecoder(NOZCompressionMethodDeflate, originalDecoder);
@@ -162,14 +188,14 @@
     // Both original
 
     [self runCodingWithMethod:NOZCompressionMethodDeflate];
-    [self runDataCodingTest:NOZCompressionMethodDeflate];
+    [self runCategoryCodingTest:NOZCompressionMethodDeflate];
 
     // Original Encoder / Custom Decoder
 
     NOZUpdateCompressionMethodDecoder(NOZCompressionMethodDeflate, [NOZXAppleCompressionCoder decoderWithAlgorithm:COMPRESSION_ZLIB]);
 
     [self runCodingWithMethod:NOZCompressionMethodDeflate];
-    [self runDataCodingTest:NOZCompressionMethodDeflate];
+    [self runCategoryCodingTest:NOZCompressionMethodDeflate];
 
     NOZUpdateCompressionMethodDecoder(NOZCompressionMethodDeflate, originalDecoder);
 
@@ -178,7 +204,7 @@
     NOZUpdateCompressionMethodEncoder(NOZCompressionMethodDeflate, [NOZXAppleCompressionCoder encoderWithAlgorithm:COMPRESSION_ZLIB]);
 
     [self runCodingWithMethod:NOZCompressionMethodDeflate];
-    [self runDataCodingTest:NOZCompressionMethodDeflate];
+    [self runCategoryCodingTest:NOZCompressionMethodDeflate];
 
     NOZUpdateCompressionMethodEncoder(NOZCompressionMethodDeflate, originalEncoder);
 
@@ -187,25 +213,25 @@
 - (void)testLZMACoding
 {
     [self runCodingWithMethod:NOZCompressionMethodLZMA];
-    [self runDataCodingTest:NOZCompressionMethodLZMA];
+    [self runCategoryCodingTest:NOZCompressionMethodLZMA];
 }
 
 - (void)testLZ4Coding
 {
     [self runCodingWithMethod:(NOZCompressionMethod)COMPRESSION_LZ4];
-    [self runDataCodingTest:(NOZCompressionMethod)COMPRESSION_LZ4];
+    [self runCategoryCodingTest:(NOZCompressionMethod)COMPRESSION_LZ4];
 }
 
 - (void)testLZFSECoding
 {
     [self runCodingWithMethod:(NOZCompressionMethod)COMPRESSION_LZFSE];
-    [self runDataCodingTest:(NOZCompressionMethod)COMPRESSION_LZFSE];
+    [self runCategoryCodingTest:(NOZCompressionMethod)COMPRESSION_LZFSE];
 }
 
 - (void)testRawCoding
 {
     [self runCodingWithMethod:NOZCompressionMethodNone];
-    [self runDataCodingTest:NOZCompressionMethodNone];
+    [self runCategoryCodingTest:NOZCompressionMethodNone];
 }
 
 @end

--- a/ZipUtilitiesTests/NOZXAppleCompressionCoderTests.m
+++ b/ZipUtilitiesTests/NOZXAppleCompressionCoderTests.m
@@ -61,9 +61,28 @@
     }
 }
 
++ (BOOL)canTestWithMethod:(NOZCompressionMethod)method
+{
+    id<NOZEncoder> checkEncoder = NOZEncoderForCompressionMethod(method);
+    id<NOZDecoder> checkDecoder = NOZDecoderForCompressionMethod(method);
+
+    if (!checkEncoder || !checkDecoder) {
+        return NO;
+    }
+
+    if (![NOZXAppleCompressionCoder isSupported]) {
+        if ([checkEncoder isKindOfClass:[NOZXAppleCompressionCoder class]] ||
+            [checkDecoder isKindOfClass:[NOZXAppleCompressionCoder class]]) {
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
 - (void)runCodingWithMethod:(NOZCompressionMethod)method
 {
-    if (![NOZXAppleCompressionCoder isSupported]) {
+    if (![[self class] canTestWithMethod:method]) {
         return;
     }
 
@@ -107,6 +126,10 @@
 
 - (void)runCategoryCodingTest:(NOZCompressionMethod)method
 {
+    if (![[self class] canTestWithMethod:method]) {
+        return;
+    }
+
     NSString *sourceFile = [[NSBundle bundleForClass:[self class]] pathForResource:@"Aesop" ofType:@"txt"];
     NSData *sourceData = [NSData dataWithContentsOfFile:sourceFile];
 


### PR DESCRIPTION
- Fix bug in Apple Encoder/Decoder
- Add convenience NSInputStream for compressed streams (could be optimized further)
