### PR TITLE
Update to 1.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## History
 
+### 1.6.6  (Oct 6, 2015) - Nolan O'Brien
+
+- Fix bug in Unzipper when "overwrite" is NO
+- Add Swift unit tests
+- Add Swift example code for operation based compression/decompression
+- Fix compression ratio of NOZDecompressResult
+
 ### 1.6.5  (Oct 4, 2015) - Nolan O'Brien
 
 - Fix bug in Apple Encoder/Decoder

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Alternatively you may use one of the following dependency managers:
 Add _ZipUtilities_ to your `Podfile`
 
 ```ruby
-pod 'ZipUtilities', '~> 1.6.5'
+pod 'ZipUtilities', '~> 1.6.6'
 ```
 
 #### Carthage
@@ -96,6 +96,33 @@ The primary value of _ZipUtilities_ is that it provides an easy to use interface
 }
 ```
 
+```swift
+func startCompression() -> NSOperation
+{
+    let request = NOZCompressRequest.init(destinationPath: self.zipFilePath)
+    request.addEntriesInDirectory(maniacDir as String, compressionSelectionBlock: nil)
+    request.addFileEntry(aesopFile as String)
+
+    let operation = NOZCompressOperation.init(request: request, delegate: self)
+    zipQueue?.addOperation(operation)
+    return operation
+}
+
+func compressOperation(op: NOZCompressOperation, didCompleteWithResult result: NOZCompressResult)
+{
+    dispatch_async(dispatch_get_main_queue(), {
+        self.completionBlock(result.didSuccess, result.operationError);
+    })
+}
+
+func compressOperation(op: NOZCompressOperation, didUpdateProgress progress: Float)
+{
+    dispatch_async(dispatch_get_main_queue(), {
+        self.progressBlock(progress);
+    })
+}
+```
+
 **`NOZDecompress.h`**
 
 `NOZDecompress.h` contains the service oriented interfaces related to decompressing from a zip archive.
@@ -110,7 +137,7 @@ The primary value of _ZipUtilities_ is that it provides an easy to use interface
 ```obj-c
 - (NSOperation *)startDecompression
 {
-    NOZDecompressRequest *request = [[NOZDecompressRequest ialloc] initWithSourceFilePath:self.zipFilePath];
+    NOZDecompressRequest *request = [[NOZDecompressRequest alloc] initWithSourceFilePath:self.zipFilePath];
 
     NOZDecompressOperation *op = [[NOZDecompressOperation alloc] initWithRequest:request delegate:self];
     [self.operationQueue addOperation:op];
@@ -131,6 +158,30 @@ The primary value of _ZipUtilities_ is that it provides an easy to use interface
 	dispatch_async(dispatch_get_main_queue(), ^{
 	    self.progressBlock(progress);
 	});
+}
+```
+
+```swift
+func startDecompression() -> NSOperation
+{
+    let request = NOZDecompressRequest.init(sourceFilePath: self.zipFilePath)
+    let operation = NOZDecompressOperation.init(request: request, delegate: self)
+    zipQueue?.addOperation(operation)
+    return operation
+}
+
+func decompressOperation(op: NOZDecompressOperation, didCompleteWithResult result: NOZDecompressResult)
+{
+    dispatch_async(dispatch_get_main_queue(), {
+        self.completionBlock(result.didSuccess, result.destinationFiles, result.operationError);
+    })
+}
+
+func decompressOperation(op: NOZDecompressOperation, didUpdateProgress progress: Float)
+{
+    dispatch_async(dispatch_get_main_queue(), {
+        self.progressBlock(progress);
+    })
 }
 ```
 

--- a/ZipUtilities.podspec
+++ b/ZipUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ZipUtilities"
-  s.version      = "1.6.5"
+  s.version      = "1.6.6"
   s.summary      = "Zip Archiving, Unarchiving and Utilities in Objective-C"
   s.description  = <<-DESC
 					ZipUtilities, prefixed with NOZ for Nolan O'Brien ZipUtilities, is a library of zipping and unzipping utilities for iOS and Mac OS X.

--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		1C7634421BB6522800BBFECF /* NOZDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7634401BB6522800BBFECF /* NOZDecoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1C7634431BB6522800BBFECF /* NOZDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7634401BB6522800BBFECF /* NOZDecoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1C7634441BB6522800BBFECF /* NOZDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7634401BB6522800BBFECF /* NOZDecoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C7B08631BC46D1600C14196 /* NOZSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7B08611BC46D1600C14196 /* NOZSwiftTests.swift */; settings = {ASSET_TAGS = (); }; };
+		1C7B08641BC46D1600C14196 /* NOZSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7B08611BC46D1600C14196 /* NOZSwiftTests.swift */; settings = {ASSET_TAGS = (); }; };
 		1CCAC7981B890FAD004AD418 /* NOZCompression.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CCAC7961B890FAD004AD418 /* NOZCompression.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1CCAC7991B890FAD004AD418 /* NOZCompression.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CCAC7971B890FAD004AD418 /* NOZCompression.m */; };
 		1CCAC79B1B8997F4004AD418 /* NOZDeflateCoders.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CCAC79A1B8997F4004AD418 /* NOZDeflateCoders.m */; };
@@ -212,6 +214,9 @@
 		1C7634311BB6455700BBFECF /* NSData+NOZAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+NOZAdditions.m"; sourceTree = "<group>"; };
 		1C7634381BB64F2100BBFECF /* NOZEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NOZEncoder.h; sourceTree = "<group>"; };
 		1C7634401BB6522800BBFECF /* NOZDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NOZDecoder.h; sourceTree = "<group>"; };
+		1C7B085F1BC46D1500C14196 /* FrameworkTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FrameworkTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		1C7B08601BC46D1500C14196 /* OSXFrameworkTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OSXFrameworkTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		1C7B08611BC46D1600C14196 /* NOZSwiftTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NOZSwiftTests.swift; sourceTree = "<group>"; };
 		1CCAC7961B890FAD004AD418 /* NOZCompression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NOZCompression.h; sourceTree = "<group>"; };
 		1CCAC7971B890FAD004AD418 /* NOZCompression.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NOZCompression.m; sourceTree = "<group>"; };
 		1CCAC79A1B8997F4004AD418 /* NOZDeflateCoders.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NOZDeflateCoders.m; sourceTree = "<group>"; };
@@ -372,6 +377,9 @@
 				1C6BF7B61B7564A700969629 /* NOZCompressTests.m */,
 				1C3223761B76FB7C00DC0A33 /* NOZDecompressTests.m */,
 				1C19A2591BA39001004E8D6C /* NOZXAppleCompressionCoderTests.m */,
+				1C7B08611BC46D1600C14196 /* NOZSwiftTests.swift */,
+				1C7B085F1BC46D1500C14196 /* FrameworkTests-Bridging-Header.h */,
+				1C7B08601BC46D1500C14196 /* OSXFrameworkTests-Bridging-Header.h */,
 			);
 			path = ZipUtilitiesTests;
 			sourceTree = "<group>";
@@ -633,6 +641,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = NOZ;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = NSProgrammer;
 				TargetAttributes = {
@@ -793,6 +802,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1C7B08631BC46D1600C14196 /* NOZSwiftTests.swift in Sources */,
 				4623A8A61B9A883A00A56535 /* NOZDecompressTests.m in Sources */,
 				1C19A25B1BA39001004E8D6C /* NOZXAppleCompressionCoderTests.m in Sources */,
 				4623A8A31B9A883600A56535 /* NOZCompressTests.m in Sources */,
@@ -825,6 +835,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1C7B08641BC46D1600C14196 /* NOZSwiftTests.swift in Sources */,
 				4623A8A51B9A883900A56535 /* NOZDecompressTests.m in Sources */,
 				1C19A25C1BA39001004E8D6C /* NOZXAppleCompressionCoderTests.m in Sources */,
 				4623A8A41B9A883600A56535 /* NOZCompressTests.m in Sources */,
@@ -989,6 +1000,7 @@
 		1C6BF7881B74086000969629 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1005,6 +1017,7 @@
 		1C6BF7891B74086000969629 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1069,6 +1082,7 @@
 		4623A8451B9A828A00A56535 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1080,12 +1094,15 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "ZipUtilitiesTests/FrameworkTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		4623A8461B9A828A00A56535 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
@@ -1093,6 +1110,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "ZipUtilitiesTests/FrameworkTests-Bridging-Header.h";
 			};
 			name = Release;
 		};
@@ -1152,6 +1170,7 @@
 		4623A8631B9A82AF00A56535 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1169,12 +1188,15 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "ZipUtilitiesTests/OSXFrameworkTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		4623A8641B9A82AF00A56535 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -1187,6 +1209,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "ZipUtilitiesTests/OSXFrameworkTests-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/ZipUtilities/Info.plist
+++ b/ZipUtilities/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.5</string>
+	<string>1.6.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ZipUtilities/NOZDecompress.m
+++ b/ZipUtilities/NOZDecompress.m
@@ -221,8 +221,8 @@ typedef NS_ENUM(NSUInteger, NOZDecompressStep)
         result.didSucceed = YES;
         result.destinationFiles = _entryPaths;
 
-        result.uncompressedSize = (SInt64)[[fm attributesOfItemAtPath:_request.sourceFilePath error:NULL] fileSize];
-        result.compressedSize = _expectedUncompressedSize;
+        result.uncompressedSize = _expectedUncompressedSize;
+        result.compressedSize = (SInt64)[[fm attributesOfItemAtPath:_request.sourceFilePath error:NULL] fileSize];
     }
     _result = result;
 

--- a/ZipUtilities/NOZUnzipper.m
+++ b/ZipUtilities/NOZUnzipper.m
@@ -322,7 +322,12 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
         return NO;
     }
 
-    FILE *file = fopen(destinationFile.UTF8String, overwrite ? "w+" : "r+");
+    if (!overwrite && [fm fileExistsAtPath:destinationFile]) {
+        stackError = [NSError errorWithDomain:NSPOSIXErrorDomain code:EEXIST userInfo:nil];
+        return NO;
+    }
+
+    FILE *file = fopen(destinationFile.UTF8String, "w+");
     if (!file) {
         stackError = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:nil];
         return NO;

--- a/ZipUtilities/OSX-Info.plist
+++ b/ZipUtilities/OSX-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.5</string>
+	<string>1.6.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ZipUtilitiesTests/FrameworkTests-Bridging-Header.h
+++ b/ZipUtilitiesTests/FrameworkTests-Bridging-Header.h
@@ -1,0 +1,7 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import <Foundation/Foundation.h>
+#import "ZipUtilities.h"
+#import "NOZXAppleCompressionCoder.h"

--- a/ZipUtilitiesTests/NOZSwiftTests.swift
+++ b/ZipUtilitiesTests/NOZSwiftTests.swift
@@ -1,0 +1,160 @@
+//
+//  NOZSwiftTests.swift
+//  ZipUtilities
+//
+//  Created by Nolan O'Brien on 10/6/15.
+//  Copyright © 2015 NSProgrammer. All rights reserved.
+//
+
+import XCTest
+
+var zipQueue : NSOperationQueue? = nil;
+
+func RemoveTemporaryDirectoryContents()
+{
+    let fm = NSFileManager.defaultManager()
+    let tmpDir : NSString = NSTemporaryDirectory()
+    let enumerator = fm.enumeratorAtPath(tmpDir as String)
+    enumerator?.skipDescendants();
+
+    for object in enumerator! {
+        let path = object as! String
+        _ = try? fm.removeItemAtPath(tmpDir.stringByAppendingPathComponent(path))
+    }
+}
+
+func SetUpZipQueue()
+{
+    let q : dispatch_queue_t = dispatch_queue_create("zip.queue", DISPATCH_QUEUE_SERIAL)
+    let opQueue = NSOperationQueue()
+    opQueue.underlyingQueue = q
+    opQueue.name = "Zip.Swift.Queue"
+    opQueue.maxConcurrentOperationCount = 1
+    zipQueue = opQueue
+}
+
+func TearDownZipQueue()
+{
+    zipQueue = nil;
+}
+
+@objc class NOZSwiftCompressionTests: XCTestCase, NOZCompressDelegate
+{
+
+    override class func setUp()
+    {
+        SetUpZipQueue()
+        RemoveTemporaryDirectoryContents()
+    }
+
+    override class func tearDown()
+    {
+        TearDownZipQueue()
+        RemoveTemporaryDirectoryContents()
+    }
+
+    override func tearDown()
+    {
+        RemoveTemporaryDirectoryContents()
+        super.tearDown()
+    }
+
+    func testCompressionOperation()
+    {
+        let op = startCompression()
+        op.waitUntilFinished()
+        XCTAssertTrue(op.finished)
+    }
+
+    func startCompression() -> NSOperation
+    {
+        let tmpDir : NSString = NSTemporaryDirectory()
+        let zipFilePath = tmpDir.stringByAppendingPathComponent("Mixed.zip")
+
+        let bundle = NSBundle.init(forClass: self.dynamicType)
+        let aesopFile : NSString = bundle.pathForResource("Aesop", ofType: "txt")!
+        let sourceDir : NSString = aesopFile.stringByDeletingLastPathComponent
+        let maniacDir : NSString = sourceDir.stringByAppendingPathComponent("maniac-mansion")
+
+        let request = NOZCompressRequest.init(destinationPath: zipFilePath)
+        request.addEntriesInDirectory(maniacDir as String, compressionSelectionBlock: nil)
+        request.addFileEntry(aesopFile as String)
+
+        let operation = NOZCompressOperation.init(request: request, delegate: self)
+        zipQueue?.addOperation(operation)
+        return operation
+    }
+
+    func compressOperation(op: NOZCompressOperation, didCompleteWithResult result: NOZCompressResult)
+    {
+        XCTAssertTrue(result.didSucceed, "Failed to compress! \(result.operationError)")
+        if (result.didSucceed) {
+            NSLog("Compression Ratio: \(result.compressionRatio())")
+        }
+    }
+
+    func compressOperation(op: NOZCompressOperation, didUpdateProgress progress: Float)
+    {
+        dispatch_async(dispatch_get_main_queue(), {
+            // NSLog("Progress: \(progress)%")
+        })
+    }
+
+}
+
+@objc class NOZSwiftDecompressionTests: XCTestCase, NOZDecompressDelegate
+{
+    override class func setUp()
+    {
+        SetUpZipQueue()
+        RemoveTemporaryDirectoryContents()
+    }
+
+    override class func tearDown()
+    {
+        TearDownZipQueue()
+        RemoveTemporaryDirectoryContents()
+    }
+
+    override func tearDown()
+    {
+        RemoveTemporaryDirectoryContents()
+        super.tearDown()
+    }
+
+    func testDecompressionOperation()
+    {
+        let op = startDecompression()
+        op.waitUntilFinished()
+        XCTAssertTrue(op.finished)
+    }
+
+    func startDecompression() -> NSOperation
+    {
+        let tmpDir : NSString = NSTemporaryDirectory()
+        let zipFilePath = tmpDir.stringByAppendingPathComponent("Mixed.zip")
+        let bundle = NSBundle.init(forClass: self.dynamicType)
+        let sourceFilePath = bundle.pathForResource("Mixed", ofType: "zip")!
+        try! NSFileManager.defaultManager().copyItemAtPath(sourceFilePath, toPath: zipFilePath)
+
+        let request = NOZDecompressRequest.init(sourceFilePath: zipFilePath)
+        let operation = NOZDecompressOperation.init(request: request, delegate: self)
+        zipQueue?.addOperation(operation)
+        return operation
+    }
+
+    func decompressOperation(op: NOZDecompressOperation, didCompleteWithResult result: NOZDecompressResult)
+    {
+        XCTAssertTrue(result.didSucceed, "Failed to decompress! \(result.operationError)")
+        if (result.didSucceed) {
+            NSLog("Compression ratio: \(result.compressionRatio())")
+        }
+    }
+
+    func decompressOperation(op: NOZDecompressOperation, didUpdateProgress progress: Float)
+    {
+        dispatch_async(dispatch_get_main_queue(), {
+            // NSLog("Progress: \(progress)%")
+        })
+    }
+}

--- a/ZipUtilitiesTests/OSXFrameworkTests-Bridging-Header.h
+++ b/ZipUtilitiesTests/OSXFrameworkTests-Bridging-Header.h
@@ -1,0 +1,7 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import <Foundation/Foundation.h>
+#import "ZipUtilities.h"
+#import "NOZXAppleCompressionCoder.h"


### PR DESCRIPTION
- Fix bug in Unzipper when "overwrite" is NO
- Add Swift unit tests
- Add Swift example code for operation based compression/decompression
- Fix compression ratio of NOZDecompressResult
