### PR TITLE
fix completion block not being called when using NOZDecompressOperation

### DIFF
--- a/ZipUtilities/NOZDecompress.m
+++ b/ZipUtilities/NOZDecompress.m
@@ -406,7 +406,7 @@ typedef NS_ENUM(NSUInteger, NOZDecompressStep)
     return YES;
 }
 
-- (void)compressOperation:(NOZDecompressOperation *)op didCompleteWithResult:(NOZDecompressResult *)result
+- (void)decompressOperation:(NOZDecompressOperation *)op didCompleteWithResult:(NOZDecompressResult *)result
 {
     if (_completionBlock) {
         _completionBlock(op, result);

--- a/ZipUtilitiesTests/NOZSwiftTests.swift
+++ b/ZipUtilitiesTests/NOZSwiftTests.swift
@@ -165,7 +165,6 @@ func TearDownZipQueue()
             expectation.fulfill()
         }
         zipQueue?.addOperation(operation)
-        operation.waitUntilFinished()
-        waitForExpectationsWithTimeout(0.0, handler: nil)
+        waitForExpectationsWithTimeout(10.0, handler: nil)
     }
 }

--- a/ZipUtilitiesTests/NOZSwiftTests.swift
+++ b/ZipUtilitiesTests/NOZSwiftTests.swift
@@ -157,4 +157,15 @@ func TearDownZipQueue()
             // NSLog("Progress: \(progress)%")
         })
     }
+    
+    func testCompletionClosureIsCalled() {
+        let expectation = expectationWithDescription("completion closure is called")
+        let request = NOZDecompressRequest(sourceFilePath: "")
+        let operation = NOZDecompressOperation(request: request) { (operation, result) -> Void in
+            expectation.fulfill()
+        }
+        zipQueue?.addOperation(operation)
+        operation.waitUntilFinished()
+        waitForExpectationsWithTimeout(0.0, handler: nil)
+    }
 }


### PR DESCRIPTION
Hello,

I've found and fixed an issue of NOZDecompressOperation. When initialized with a completion block instead of a delegate, the completion block is not called. There was a typo in a method name. I've fixed it and added a test case. Please review my changes and merge if you like.

Best regards

Changbeom Ahn
