### PR TITLE
Minor cleanup

### DIFF
--- a/Extra/NOZXAppleCompressionCoder.h
+++ b/Extra/NOZXAppleCompressionCoder.h
@@ -8,9 +8,9 @@
 
 @import ZipUtilities;
 
-#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
+#if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
 #define COMPRESSION_LIB_AVAILABLE 1
-#elif TARGET_OS_MAC && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1011
+#elif TARGET_OS_MAC && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
 #define COMPRESSION_LIB_AVAILABLE 1
 #else
 #define COMPRESSION_LIB_AVAILABLE 0
@@ -27,8 +27,8 @@
 + (nullable id<NOZEncoder>)encoderWithAlgorithm:(compression_algorithm)algorithm;
 + (nullable id<NOZDecoder>)decoderWithAlgorithm:(compression_algorithm)algorithm;
 
-- (nullable instancetype)init NS_UNAVAILABLE;
-+ (nullable instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 
 @end
 

--- a/Extra/NOZXAppleCompressionCoder.m
+++ b/Extra/NOZXAppleCompressionCoder.m
@@ -71,12 +71,12 @@
 #endif
 }
 
-+ (nullable id<NOZEncoder>)encoderWithAlgorithm:(compression_algorithm)algorithm
++ (id<NOZEncoder>)encoderWithAlgorithm:(compression_algorithm)algorithm
 {
     return [self isSupported] ? [[self alloc] initWithAlgorithm:algorithm operation:COMPRESSION_STREAM_ENCODE] : nil;
 }
 
-+ (nullable id<NOZDecoder>)decoderWithAlgorithm:(compression_algorithm)algorithm
++ (id<NOZDecoder>)decoderWithAlgorithm:(compression_algorithm)algorithm
 {
     return [self isSupported] ? [[self alloc] initWithAlgorithm:algorithm operation:COMPRESSION_STREAM_DECODE] : nil;
 }

--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -945,7 +945,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -996,7 +996,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -1072,7 +1072,7 @@
 				);
 				INFOPLIST_FILE = ZipUtilities/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "-ObjC";
@@ -1096,7 +1096,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ZipUtilities/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "-ObjC";
@@ -1119,7 +1119,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -1135,7 +1135,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -1213,7 +1213,7 @@
 				);
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1234,7 +1234,7 @@
 				);
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ZipUtilities/NOZDeflateCoders.m
+++ b/ZipUtilities/NOZDeflateCoders.m
@@ -57,7 +57,7 @@
     return &_zStream;
 }
 
-- (nonnull instancetype)init
+- (instancetype)init
 {
     if (self = [super init]) {
         _compressedDataBuffer = malloc(NSPageSize());
@@ -90,7 +90,7 @@
 
 @implementation NOZDeflateEncoder
 
-- (UInt16)bitFlagsForEntry:(nonnull id<NOZZipEntry>)entry
+- (UInt16)bitFlagsForEntry:(id<NOZZipEntry>)entry
 {
     switch (entry.compressionLevel) {
         case 9:
@@ -105,9 +105,9 @@
     }
 }
 
-- (nonnull NOZDeflateEncoderContext *)createContextWithBitFlags:(UInt16)bitFlags
-                                               compressionLevel:(NOZCompressionLevel)level
-                                                  flushCallback:(nonnull NOZFlushCallback)callback;
+- (NOZDeflateEncoderContext *)createContextWithBitFlags:(UInt16)bitFlags
+                                       compressionLevel:(NOZCompressionLevel)level
+                                          flushCallback:(NOZFlushCallback)callback;
 {
     NOZDeflateEncoderContext *context = [[NOZDeflateEncoderContext alloc] init];
     context.flushCallback = callback;
@@ -115,7 +115,7 @@
     return context;
 }
 
-- (BOOL)initializeEncoderContext:(nonnull NOZDeflateEncoderContext *)context
+- (BOOL)initializeEncoderContext:(NOZDeflateEncoderContext *)context
 {
     if (Z_OK != deflateInit2(context.zStream,
                              context.compressionLevel,
@@ -130,9 +130,9 @@
     return YES;
 }
 
-- (BOOL)encodeBytes:(nonnull const Byte*)bytes
+- (BOOL)encodeBytes:(const Byte*)bytes
              length:(size_t)length
-            context:(nonnull NOZDeflateEncoderContext *)context
+            context:(NOZDeflateEncoderContext *)context
 {
     if (!context.zStreamOpen) {
         return NO;
@@ -171,7 +171,7 @@
     return success;
 }
 
-- (BOOL)finalizeEncoderContext:(nonnull NOZDeflateEncoderContext *)context
+- (BOOL)finalizeEncoderContext:(NOZDeflateEncoderContext *)context
 {
     if (!context.zStreamOpen) {
         return NO;
@@ -302,15 +302,15 @@
 
 @implementation NOZDeflateDecoder
 
-- (nonnull NOZDeflateDecoderContext *)createContextForDecodingWithBitFlags:(UInt16)bitFlags
-                                                             flushCallback:(nonnull NOZFlushCallback)callback
+- (NOZDeflateDecoderContext *)createContextForDecodingWithBitFlags:(UInt16)bitFlags
+                                                     flushCallback:(NOZFlushCallback)callback
 {
     NOZDeflateDecoderContext *context = [[NOZDeflateDecoderContext alloc] init];
     context.flushCallback = callback;
     return context;
 }
 
-- (BOOL)initializeDecoderContext:(nonnull NOZDeflateDecoderContext *)context
+- (BOOL)initializeDecoderContext:(NOZDeflateDecoderContext *)context
 {
     if (Z_OK != inflateInit2(context.zStream, -MAX_WBITS)) {
         return NO;
@@ -319,9 +319,9 @@
     return YES;
 }
 
-- (BOOL)decodeBytes:(nonnull const Byte*)bytes
+- (BOOL)decodeBytes:(const Byte*)bytes
              length:(size_t)length
-            context:(nonnull NOZDeflateDecoderContext *)context
+            context:(NOZDeflateDecoderContext *)context
 {
     if (context.hasFinished) {
         return YES;
@@ -392,7 +392,7 @@
     return YES;
 }
 
-- (BOOL)finalizeDecoderContext:(nonnull NOZDeflateDecoderContext *)context
+- (BOOL)finalizeDecoderContext:(NOZDeflateDecoderContext *)context
 {
     if (context.zStreamOpen) {
         inflateEnd(context.zStream);

--- a/ZipUtilities/NOZRawCoders.m
+++ b/ZipUtilities/NOZRawCoders.m
@@ -43,28 +43,28 @@
 
 @implementation NOZRawEncoder
 
-- (UInt16)bitFlagsForEntry:(nonnull id<NOZZipEntry>)entry
+- (UInt16)bitFlagsForEntry:(id<NOZZipEntry>)entry
 {
     return 0;
 }
 
-- (nonnull NOZRawEncoderContext *)createContextWithBitFlags:(UInt16)bitFlags
-                                           compressionLevel:(NOZCompressionLevel)level
-                                              flushCallback:(nonnull NOZFlushCallback)callback;
+- (NOZRawEncoderContext *)createContextWithBitFlags:(UInt16)bitFlags
+                                   compressionLevel:(NOZCompressionLevel)level
+                                      flushCallback:(NOZFlushCallback)callback;
 {
     NOZRawEncoderContext *context = [[NOZRawEncoderContext alloc] init];
     context.flushCallback = callback;
     return context;
 }
 
-- (BOOL)initializeEncoderContext:(nonnull NOZRawEncoderContext *)context
+- (BOOL)initializeEncoderContext:(NOZRawEncoderContext *)context
 {
     return YES;
 }
 
-- (BOOL)encodeBytes:(nonnull const Byte*)bytes
+- (BOOL)encodeBytes:(const Byte*)bytes
              length:(size_t)length
-            context:(nonnull NOZRawEncoderContext *)context
+            context:(NOZRawEncoderContext *)context
 {
     // direct passthrough
     if (!context.flushCallback(self, context, bytes, length)) {
@@ -74,7 +74,7 @@
     return YES;
 }
 
-- (BOOL)finalizeEncoderContext:(nonnull NOZRawEncoderContext *)context
+- (BOOL)finalizeEncoderContext:(NOZRawEncoderContext *)context
 {
     context.flushCallback = NULL;
     return YES;
@@ -94,22 +94,22 @@
 
 @implementation NOZRawDecoder
 
-- (nonnull NOZRawDecoderContext *)createContextForDecodingWithBitFlags:(UInt16)bitFlags
-                                                         flushCallback:(nonnull NOZFlushCallback)callback
+- (NOZRawDecoderContext *)createContextForDecodingWithBitFlags:(UInt16)bitFlags
+                                                 flushCallback:(NOZFlushCallback)callback
 {
     NOZRawDecoderContext *context = [[NOZRawDecoderContext alloc] init];
     context.flushCallback = callback;
     return context;
 }
 
-- (BOOL)initializeDecoderContext:(nonnull NOZRawDecoderContext *)context
+- (BOOL)initializeDecoderContext:(NOZRawDecoderContext *)context
 {
     return YES;
 }
 
-- (BOOL)decodeBytes:(nonnull const Byte*)bytes
+- (BOOL)decodeBytes:(const Byte*)bytes
              length:(size_t)length
-            context:(nonnull NOZRawDecoderContext *)context
+            context:(NOZRawDecoderContext *)context
 {
     if (context.hasFinished) {
         return YES;
@@ -127,7 +127,7 @@
     return YES;
 }
 
-- (BOOL)finalizeDecoderContext:(nonnull NOZRawDecoderContext *)context
+- (BOOL)finalizeDecoderContext:(NOZRawDecoderContext *)context
 {
     context.flushCallback = NULL;
     return YES;

--- a/ZipUtilities/NOZSyncStepOperation.m
+++ b/ZipUtilities/NOZSyncStepOperation.m
@@ -146,7 +146,7 @@
     return YES;
 }
 
-+ (nonnull NSError *)operationCancelledError
++ (NSError *)operationCancelledError
 {
     @throw [NSException exceptionWithName:NSInvalidArgumentException
                                    reason:@"does not recognize selector!"

--- a/ZipUtilities/NOZUnzipper.h
+++ b/ZipUtilities/NOZUnzipper.h
@@ -179,9 +179,9 @@ typedef NS_OPTIONS(NSInteger, NOZUnzipperSaveRecordOptions)
 - (nonnull instancetype)initWithZipFile:(nonnull NSString *)zipFilePath;
 
 /** Unavailable */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
 /** Unavailable */
-+ (nullable instancetype)new NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 
 /**
  Open the zip archive.
@@ -269,9 +269,9 @@ typedef NS_OPTIONS(NSInteger, NOZUnzipperSaveRecordOptions)
 @property (nonatomic, readonly) SInt64 uncompressedSize;
 
 /** Unavailable */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
 /** Unavailable */
-+ (nullable instancetype)new NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 @end
 
 /**
@@ -300,8 +300,8 @@ typedef NS_OPTIONS(NSInteger, NOZUnzipperSaveRecordOptions)
 @property (nonatomic, readonly) SInt64 totalUncompressedSize;
 
 /** Unavailable */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
 /** Unavailable */
-+ (nullable instancetype)new NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 @end
 

--- a/ZipUtilities/NOZUnzipper.m
+++ b/ZipUtilities/NOZUnzipper.m
@@ -94,7 +94,7 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
     [self closeAndReturnError:NULL];
 }
 
-- (nonnull instancetype)initWithZipFile:(nonnull NSString *)zipFilePath
+- (instancetype)initWithZipFile:(NSString *)zipFilePath
 {
     if (self = [super init]) {
         _zipFilePath = [zipFilePath copy];
@@ -108,7 +108,7 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
     abort();
 }
 
-- (BOOL)openAndReturnError:(out NSError *__autoreleasing  __nullable * __nullable)error
+- (BOOL)openAndReturnError:(out NSError **)error
 {
     NSError *stackError = NOZError(NOZErrorCodeUnzipCannotOpenZip, @{ @"zipFilePath" : [self zipFilePath] ?: [NSNull null] });
     _standardizedFilePath = [self.zipFilePath stringByStandardizingPath];
@@ -132,7 +132,7 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
     return NO;
 }
 
-- (BOOL)closeAndReturnError:(out NSError *__autoreleasing  __nullable * __nullable)error
+- (BOOL)closeAndReturnError:(out NSError **)error
 {
     _centralDirectory = nil;
     if (_internal.file) {
@@ -142,7 +142,7 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
     return YES;
 }
 
-- (nullable NOZCentralDirectory *)readCentralDirectoryAndReturnError:(out NSError * __nullable * __nullable)error
+- (NOZCentralDirectory *)readCentralDirectoryAndReturnError:(out NSError **)error
 {
     __block NSError *stackError = nil;
     noz_defer(^{
@@ -175,7 +175,7 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
     return cd;
 }
 
-- (nullable NOZCentralDirectoryRecord *)readRecordAtIndex:(NSUInteger)index error:(out NSError * __nullable * __nullable)error
+- (NOZCentralDirectoryRecord *)readRecordAtIndex:(NSUInteger)index error:(out NSError **)error
 {
     if (index >= _centralDirectory.recordCount) {
         if (error) {
@@ -186,12 +186,12 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
     return [_centralDirectory recordAtIndex:index];
 }
 
-- (NSUInteger)indexForRecordWithName:(nonnull NSString *)name
+- (NSUInteger)indexForRecordWithName:(NSString *)name
 {
     return (_centralDirectory) ? [_centralDirectory indexForRecordWithName:name] : NSNotFound;
 }
 
-- (void)enumerateManifestEntriesUsingBlock:(nonnull NOZUnzipRecordEnumerationBlock)block
+- (void)enumerateManifestEntriesUsingBlock:(NOZUnzipRecordEnumerationBlock)block
 {
     [_centralDirectory.internalRecords enumerateObjectsUsingBlock:block];
 }
@@ -283,9 +283,9 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
     return YES;
 }
 
-- (NSData *)readDataFromRecord:(nonnull NOZCentralDirectoryRecord *)record
-                 progressBlock:(nullable NOZProgressBlock)progressBlock
-                         error:(out NSError * __nullable __autoreleasing * __nullable)error
+- (NSData *)readDataFromRecord:(NOZCentralDirectoryRecord *)record
+                 progressBlock:(NOZProgressBlock)progressBlock
+                         error:(out NSError **)error
 {
     __block NSMutableData *data = nil;
     if (![self enumerateByteRangesOfRecord:record
@@ -306,8 +306,8 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
 - (BOOL)saveRecord:(NOZCentralDirectoryRecord *)record
        toDirectory:(NSString *)destinationRootDirectory
    shouldOverwrite:(BOOL)overwrite
-     progressBlock:(nullable NOZProgressBlock)progressBlock
-             error:(out NSError * __nullable __autoreleasing * __nullable)error
+     progressBlock:(NOZProgressBlock)progressBlock
+             error:(out NSError **)error
 {
     return [self saveRecord:record
                 toDirectory:destinationRootDirectory
@@ -320,7 +320,7 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
        toDirectory:(NSString *)destinationRootDirectory
            options:(NOZUnzipperSaveRecordOptions)options
      progressBlock:(NOZProgressBlock)progressBlock
-             error:(out NSError * _Nullable __autoreleasing *)error
+             error:(out NSError **)error
 {
     __block NSError *stackError = nil;
     noz_defer(^{
@@ -393,7 +393,7 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
 
 @implementation NOZUnzipper (Private)
 
-- (BOOL)private_flushDecompressedBytes:(const Byte *)buffer length:(size_t)length block:(nonnull NOZUnzipByteRangeEnumerationBlock)block
+- (BOOL)private_flushDecompressedBytes:(const Byte *)buffer length:(size_t)length block:(NOZUnzipByteRangeEnumerationBlock)block
 {
     _currentUnzipping.crc32 = (UInt32)crc32(_currentUnzipping.crc32, buffer, (UInt32)length);
     _currentUnzipping.bytesDecompressed += length;
@@ -519,7 +519,9 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
     return YES;
 }
 
-- (BOOL)private_deflateWithProgressBlock:(nullable NOZProgressBlock)progressBlock usingBlock:(nonnull NOZUnzipByteRangeEnumerationBlock)block error:(out NSError * __nullable __autoreleasing * __nullable)error
+- (BOOL)private_deflateWithProgressBlock:(NOZProgressBlock)progressBlock
+                              usingBlock:(NOZUnzipByteRangeEnumerationBlock)block
+                                   error:(out NSError **)error
 {
     __block BOOL success = YES;
     noz_defer(^{
@@ -586,13 +588,13 @@ static BOOL noz_fread_value(FILE *file, Byte* value, const UInt8 byteCount);
 {
 }
 
-- (nullable instancetype)init
+- (instancetype)init
 {
     [self doesNotRecognizeSelector:_cmd];
     abort();
 }
 
-- (nonnull instancetype)initWithKnownFileSize:(SInt64)fileSize
+- (instancetype)initWithKnownFileSize:(SInt64)fileSize
 {
     if (self = [super init]) {
         _totalUncompressedSize = fileSize;

--- a/ZipUtilities/NOZZipEntry.h
+++ b/ZipUtilities/NOZZipEntry.h
@@ -60,8 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (SInt64)sizeInBytes;
 /** Is the entry valid for zipping. */
 - (BOOL)canBeZipped;
-/** Input Stream for reading the entry into the zip file. */
-- (NSInputStream *)inputStream;
+/** Input Stream for reading the entry into the zip file.  Return `nil` if no input stream is available. */
+- (nullable NSInputStream *)inputStream;
 
 @end
 

--- a/ZipUtilities/NOZZipEntry.m
+++ b/ZipUtilities/NOZZipEntry.m
@@ -39,7 +39,7 @@
     abort();
 }
 
-- (instancetype)initWithName:(nonnull NSString *)name
+- (instancetype)initWithName:(NSString *)name
 {
     if (self = [super init]) {
         _name = [name copy];
@@ -49,7 +49,7 @@
     return self;
 }
 
-- (instancetype)initWithEntry:(nonnull NOZAbstractZipEntry *)entry
+- (instancetype)initWithEntry:(NOZAbstractZipEntry *)entry
 {
     return [self initWithName:entry.name];
 }
@@ -82,13 +82,13 @@
 
 @implementation NOZDataZipEntry
 
-- (instancetype)initWithName:(nonnull NSString *)name
+- (instancetype)initWithName:(NSString *)name
 {
     [self doesNotRecognizeSelector:_cmd];
     abort();
 }
 
-- (instancetype)initWithData:(nonnull NSData *)data name:(nonnull NSString *)name
+- (instancetype)initWithData:(NSData *)data name:(NSString *)name
 {
     if (self = [super initWithName:name]) {
         _data = data;
@@ -96,7 +96,7 @@
     return self;
 }
 
-- (instancetype)initWithEntry:(nonnull NOZDataZipEntry *)entry
+- (instancetype)initWithEntry:(NOZDataZipEntry *)entry
 {
     return [self initWithData:entry.data name:entry.name];
 }
@@ -125,13 +125,13 @@
 
 @implementation NOZFileZipEntry
 
-- (instancetype)initWithName:(nonnull NSString *)name
+- (instancetype)initWithName:(NSString *)name
 {
     [self doesNotRecognizeSelector:_cmd];
     abort();
 }
 
-- (instancetype)initWithFilePath:(nonnull NSString *)filePath name:(nonnull NSString *)name
+- (instancetype)initWithFilePath:(NSString *)filePath name:(NSString *)name
 {
     if (self = [super initWithName:name]) {
         _filePath = [filePath copy];
@@ -139,12 +139,12 @@
     return self;
 }
 
-- (instancetype)initWithFilePath:(nonnull NSString *)filePath
+- (instancetype)initWithFilePath:(NSString *)filePath
 {
     return [self initWithFilePath:filePath name:filePath.lastPathComponent];
 }
 
-- (instancetype)initWithEntry:(nonnull NOZFileZipEntry *)entry
+- (instancetype)initWithEntry:(NOZFileZipEntry *)entry
 {
     return [self initWithFilePath:entry.filePath name:entry.name];
 }

--- a/ZipUtilities/NOZZipper.h
+++ b/ZipUtilities/NOZZipper.h
@@ -113,9 +113,9 @@ typedef NS_ENUM(NSInteger, NOZZipperMode)
 - (nonnull instancetype)initWithZipFile:(nonnull NSString *)zipFilePath NS_DESIGNATED_INITIALIZER;
 
 /** Unavailable */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
 /** Unavailable */
-+ (nullable instancetype)new NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 
 /** 
  Open the Zipper.

--- a/ZipUtilities/NOZZipper.m
+++ b/ZipUtilities/NOZZipper.m
@@ -100,7 +100,7 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
     abort();
 }
 
-- (instancetype)initWithZipFile:(nonnull NSString *)zipFilePath
+- (instancetype)initWithZipFile:(NSString *)zipFilePath
 {
     if (self = [super init]) {
         _zipFilePath = [zipFilePath copy];
@@ -119,7 +119,7 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
     [self private_freeLinkedList];
 }
 
-- (BOOL)openWithMode:(NOZZipperMode)mode error:(out NSError * __nullable * __nullable)error
+- (BOOL)openWithMode:(NOZZipperMode)mode error:(out NSError **)error
 {
     if (_internal.file) {
         return YES;
@@ -198,19 +198,19 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
     return YES;
 }
 
-- (BOOL)closeAndReturnError:(out NSError * __nullable * __nullable)error
+- (BOOL)closeAndReturnError:(out NSError **)error
 {
     return [self private_forciblyClose:NO error:error];
 }
 
-- (BOOL)forciblyCloseAndReturnError:(out NSError * __nullable * __nullable)error
+- (BOOL)forciblyCloseAndReturnError:(out NSError **)error
 {
     return [self private_forciblyClose:YES error:error];
 }
 
-- (BOOL)addEntry:(nonnull id<NOZZippableEntry>)entry
-   progressBlock:(__attribute__((noescape)) NOZProgressBlock __nullable)progressBlock
-           error:(out NSError * __nullable * __nullable)error
+- (BOOL)addEntry:(id<NOZZippableEntry>)entry
+   progressBlock:(__attribute__((noescape)) NOZProgressBlock)progressBlock
+           error:(out NSError **)error
 {
     if (![self private_openEntry:entry error:error]) {
         return NO;
@@ -237,7 +237,7 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
 
 @implementation NOZZipper (Private)
 
-- (BOOL)private_forciblyClose:(BOOL)forceClose error:(out NSError * __nullable * __nullable)error
+- (BOOL)private_forciblyClose:(BOOL)forceClose error:(out NSError **)error
 {
     if (!_internal.file) {
         return YES;
@@ -288,8 +288,8 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
     return YES;
 }
 
-- (BOOL)private_openEntry:(nonnull id<NOZZippableEntry>)entry
-                    error:(out NSError * __nullable * __nullable)error
+- (BOOL)private_openEntry:(id<NOZZippableEntry>)entry
+                    error:(out NSError **)error
 {
     __block BOOL errorEncountered = NO;
     noz_defer(^{ if (errorEncountered && error) { *error = NOZError(NOZErrorCodeZipCannotOpenNewEntry, nil); } });
@@ -368,10 +368,10 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
     return YES;
 }
 
-- (BOOL)private_writeEntry:(nonnull id<NOZZippableEntry>)entry
-             progressBlock:(nullable NOZProgressBlock)progressBlock
-                     error:(out NSError * __nullable * __nullable)error
-                  abortRef:(nonnull BOOL *)abort
+- (BOOL)private_writeEntry:(id<NOZZippableEntry>)entry
+             progressBlock:(NOZProgressBlock)progressBlock
+                     error:(out NSError **)error
+                  abortRef:(BOOL *)abort
 {
     __block BOOL success = YES;
     noz_defer(^{
@@ -384,14 +384,14 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
         }
     });
 
-    if (success && (!_internal.currentEntry || !entry.inputStream)) {
+    NSInputStream *inputStream = entry.inputStream;
+    if (success && (!_internal.currentEntry || !inputStream)) {
         success = NO;
         return NO;
     }
 
     const SInt64 totalBytes = entry.sizeInBytes;
     if (success) {
-        NSInputStream *inputStream = entry.inputStream;
         [inputStream open];
         noz_defer(^{ [inputStream close]; });
         NSInteger bytesRead;
@@ -435,7 +435,7 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
     return success;
 }
 
-- (BOOL)private_closeCurrentOpenEntryAndReturnError:(out NSError * __nullable * __nullable)error
+- (BOOL)private_closeCurrentOpenEntryAndReturnError:(out NSError **)error
 {
     if (!_internal.currentEntry) {
         return YES;
@@ -491,7 +491,7 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
     return success;
 }
 
-- (BOOL)private_populateRecordsForCurrentOpenEntryWithEntry:(nonnull id<NOZZippableEntry>)entry error:(out NSError * __nullable * __nullable)error
+- (BOOL)private_populateRecordsForCurrentOpenEntryWithEntry:(id<NOZZippableEntry>)entry error:(out NSError **)error
 {
     NSUInteger nameSize = [entry.name lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
     if (nameSize > UINT16_MAX) {
@@ -612,7 +612,7 @@ noz_fwrite_value((v), sizeof(v), _internal.file)
     return (diff == expectedBytesWritten);
 }
 
-- (BOOL)private_writeLocalFileHeaderForCurrentEntryAndReturnError:(out NSError * __nullable * __nullable)error
+- (BOOL)private_writeLocalFileHeaderForCurrentEntryAndReturnError:(out NSError **)error
 {
     BOOL success = YES;
     NOZFileEntryT *entry = _internal.currentEntry;

--- a/ZipUtilities/NOZ_Project.m
+++ b/ZipUtilities/NOZ_Project.m
@@ -43,7 +43,7 @@
  11-15	Hour (0–23 on a 24-hour clock)
  */
 
-void noz_dos_date_from_NSDate(NSDate *__nullable dateObject, UInt16* dateOut, UInt16* timeOut)
+void noz_dos_date_from_NSDate(NSDate *dateObject, UInt16* dateOut, UInt16* timeOut)
 {
     if (!dateObject) {
         *dateOut = 0;

--- a/ZipUtilities/NSStream+NOZAdditions.m
+++ b/ZipUtilities/NSStream+NOZAdditions.m
@@ -73,8 +73,8 @@ static void NOZStreamCreateBoundPairCompat(CFAllocatorRef       alloc,
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-designated-initializers"
 
-- (nonnull instancetype)initWithInputStream:(nonnull NSInputStream *)stream
-                                    encoder:(nonnull id<NOZEncoder>)encoder
+- (nonnull instancetype)initWithInputStream:(NSInputStream *)stream
+                                    encoder:(id<NOZEncoder>)encoder
                            compressionLevel:(NOZCompressionLevel)compressionLevel
 {
     if (self = [super init]) {
@@ -213,7 +213,7 @@ static void NOZStreamCreateBoundPairCompat(CFAllocatorRef       alloc,
     return returnValue;
 }
 
-- (BOOL)getBuffer:(uint8_t * __nullable * __nonnull)buffer length:(NSUInteger *)len
+- (BOOL)getBuffer:(uint8_t **)buffer length:(NSUInteger *)len
 {
     return NO;
 }


### PR DESCRIPTION
- cleanup COMPRESSION_LIB_AVAILABLE definitions
- cleanup nullability attributes in .m files
- mark unavailable -init and +new as nonnull
- permit nullable inputStream for NOZZippableEntry
