### PR TITLE
updates for building in Xcode 8.3

### DIFF
--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -1407,7 +1407,7 @@
 			attributes = {
 				CLASSPREFIX = NOZ;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = NSProgrammer;
 				TargetAttributes = {
 					1C6BF76F1B74086000969629 = {
@@ -1932,7 +1932,6 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1987,7 +1986,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -2003,7 +2001,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/ZipUtilities;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -2018,7 +2015,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/ZipUtilities;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -2037,7 +2033,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -2052,7 +2047,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -2077,7 +2071,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2100,7 +2093,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2166,7 +2158,6 @@
 				PRODUCT_NAME = ZipUtilities;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2190,7 +2181,6 @@
 				PRODUCT_NAME = ZipUtilities;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities Framework.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities Framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities OSX Framework.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities OSX Framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilitiesTests/NOZSwiftTests.swift
+++ b/ZipUtilitiesTests/NOZSwiftTests.swift
@@ -102,7 +102,7 @@ func TearDownZipQueue()
 
     func compressOperation(_ op: NOZCompressOperation, didCompleteWith result: NOZCompressResult)
     {
-        XCTAssertTrue(result.didSucceed, "Failed to compress! \(result.operationError)")
+        XCTAssertTrue(result.didSucceed, "Failed to compress! \(String(describing: result.operationError))")
         if (result.didSucceed) {
             NSLog("Compression Ratio: \(result.compressionRatio())")
         }
@@ -199,7 +199,7 @@ func TearDownZipQueue()
 
     func decompressOperation(_ op: NOZDecompressOperation, didCompleteWith result: NOZDecompressResult)
     {
-        XCTAssertTrue(result.didSucceed, "Failed to decompress! \(result.operationError)")
+        XCTAssertTrue(result.didSucceed, "Failed to decompress! \(String(describing: result.operationError))")
         if (result.didSucceed) {
             NSLog("Compression ratio: \(result.compressionRatio())")
         }


### PR DESCRIPTION
- NOZSwiftTests.swift was flagged with a suggested change to
  use String(describing:) for a optiona String?

- no need for SWIFT_VERSION in project settings or in 
  settings specific to targets with no Swift in them.

- update lastVersionCheck/lastVersionUpgrade to 0830