### PR TITLE
update travis.yml: use '-sdk iphonesimulator' & 'clean test'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ osx_image: xcode8
 language: objective-c
 script:
 # iOS Static Lib
-- xcodebuild -destination "platform=iOS Simulator,name=iPhone 7" -project ZipUtilities.xcodeproj -scheme ZipUtilities -sdk iphonesimulator10.0 build test
+- xcodebuild -destination "platform=iOS Simulator,name=iPhone 7" -project ZipUtilities.xcodeproj -scheme ZipUtilities -sdk iphonesimulator clean test
 # iOS Framework (disabled since it requires code signing with latest Xcode and we don't provide a code signer with the open source project)
-#- xcodebuild -destination "platform=iOS Simulator,name=iPhone 7" -project ZipUtilities.xcodeproj -scheme "ZipUtilities Framework" -sdk iphonesimulator10.0 build test
+#- xcodebuild -destination "platform=iOS Simulator,name=iPhone 7" -project ZipUtilities.xcodeproj -scheme "ZipUtilities Framework" -sdk iphonesimulator clean test
 # Mac OS X (macOS) Framework
-- xcodebuild -project ZipUtilities.xcodeproj -scheme "ZipUtilities OSX Framework" build test
+- xcodebuild -project ZipUtilities.xcodeproj -scheme "ZipUtilities OSX Framework" clean test


### PR DESCRIPTION
the server running the tests apparently no longer can handle
'sdk iphonesimulator10.0' .

also, 'build test' is redundant, since 'test' will perform
'build' .  by performing a clean first, the test environment
is more likely ensured to be pristine.