### PR TITLE
Remove unnecessary semicolon.

### DIFF
--- a/ZipUtilities/NOZDeflateCoders.m
+++ b/ZipUtilities/NOZDeflateCoders.m
@@ -123,7 +123,7 @@ static UInt16 NOZCompressionLevelToDeflateLevel(NOZCompressionLevel level);
 
 - (NOZDeflateEncoderContext *)createContextWithBitFlags:(UInt16)bitFlags
                                        compressionLevel:(NOZCompressionLevel)level
-                                          flushCallback:(NOZFlushCallback)callback;
+                                          flushCallback:(NOZFlushCallback)callback
 {
     NOZDeflateEncoderContext *context = [[NOZDeflateEncoderContext alloc] init];
     context.flushCallback = callback;

--- a/ZipUtilities/NOZRawCoders.m
+++ b/ZipUtilities/NOZRawCoders.m
@@ -50,7 +50,7 @@
 
 - (NOZRawEncoderContext *)createContextWithBitFlags:(UInt16)bitFlags
                                    compressionLevel:(NOZCompressionLevel)level
-                                      flushCallback:(NOZFlushCallback)callback;
+                                      flushCallback:(NOZFlushCallback)callback
 {
     NOZRawEncoderContext *context = [[NOZRawEncoderContext alloc] init];
     context.flushCallback = callback;


### PR DESCRIPTION
These semicolons are not needed.