### PR TITLE
accept most Xcode 10.2.1 update suggestions

### DIFF
--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -1830,7 +1830,7 @@
 			attributes = {
 				CLASSPREFIX = NOZ;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = NSProgrammer;
 				TargetAttributes = {
 					1C6BF76F1B74086000969629 = {
@@ -1860,7 +1860,7 @@
 					};
 					4623A8551B9A82AF00A56535 = {
 						CreatedOnToolsVersion = 6.4;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 1020;
 					};
 					8B0455091DF8D81300EBB706 = {
 						CreatedOnToolsVersion = 8.1;
@@ -1882,10 +1882,9 @@
 			};
 			buildConfigurationList = 1C6BF76B1B74086000969629 /* Build configuration list for PBXProject "ZipUtilities" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -2384,6 +2383,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
@@ -2449,6 +2449,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities Framework.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities Framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities OSX Framework.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities OSX Framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilitiesApp.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilitiesApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libZipUtilities-mac.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libZipUtilities-mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libbrotli-mac.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libbrotli-mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libbrotli.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libbrotli.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libzstd-mac.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libzstd-mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libzstd.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libzstd.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/noz -Release.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/noz -Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/noz.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/noz.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
- accept suggestion for localization migration to use
  "developmentRegion = en" (vs "developmentRegion = English")
- accept suggestion for
  "CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES"
- accepted suggestion to perform Swift 5.0 migration
  - no changes (thus setting "LastSwiftMigration = 1020")
- then reverted to using Swift 4.2 in order that developers
  using Xcode 10.0 and 10.1 can continue building the tests
  (thus leaving setting "SWIFT_VERSION = 4.2"
- project.pbxproj updated to "LastUpgradeCheck = 1020"
- all .xcscheme files updated to 'LastUpgradeVersion = "1020"'

- currently rejected suggestion for Swift module optimization level
  (still under test with Xcode 10.2.1)