### PR TITLE
Xcode 11: unset CODE_SIGN_IDENTITY for iOS SDK 13 so xcodebuild works

### DIFF
--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -2616,6 +2616,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos13.0]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2638,6 +2639,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos13.0]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
in Xcode 11, when CODE_SIGN_IDENTITY is left unchanged, the default
is set to "Apple Developer" (as seen in the settings UI), and this
causes attempts to build for Distribution to break for .app products
that include ZipUtilities.framework .

setting the value to "" (i.e. empty) eliminates the diagnostics and
allows the xcodebuild to proceed.