### PR TITLE
modular header style for public headers

### DIFF
--- a/ZipUtilities/NOZCompress.h
+++ b/ZipUtilities/NOZCompress.h
@@ -27,9 +27,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZError.h"
-#import "NOZSyncStepOperation.h"
-#import "NOZZipEntry.h"
+#import <ZipUtilities/NOZError.h>
+#import <ZipUtilities/NOZSyncStepOperation.h>
+#import <ZipUtilities/NOZZipEntry.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ZipUtilities/NOZCompressionLibrary.h
+++ b/ZipUtilities/NOZCompressionLibrary.h
@@ -28,7 +28,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZCompression.h"
+#import <ZipUtilities/NOZCompression.h>
 
 @protocol NOZDecoder;
 @protocol NOZEncoder;

--- a/ZipUtilities/NOZDecoder.h
+++ b/ZipUtilities/NOZDecoder.h
@@ -27,7 +27,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZCompression.h"
+#import <ZipUtilities/NOZCompression.h>
 
 /**
  Protocol for encapsulating the context and state of a decoding process.

--- a/ZipUtilities/NOZEncoder.h
+++ b/ZipUtilities/NOZEncoder.h
@@ -27,7 +27,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZCompression.h"
+#import <ZipUtilities/NOZCompression.h>
 
 /**
  Protocol for encapsulating the context and state of an encoding process.

--- a/ZipUtilities/NOZUnzipper.h
+++ b/ZipUtilities/NOZUnzipper.h
@@ -27,8 +27,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZUtils.h"
-#import "NOZZipEntry.h"
+#import <ZipUtilities/NOZUtils.h>
+#import <ZipUtilities/NOZZipEntry.h>
 
 @class NOZGlobalInfo;
 @class NOZCentralDirectory;

--- a/ZipUtilities/NOZUtils.h
+++ b/ZipUtilities/NOZUtils.h
@@ -25,7 +25,7 @@
 //  SOFTWARE.
 //
 
-#import "NOZCompression.h"
+#import <ZipUtilities/NOZCompression.h>
 
 @protocol NOZEncoder;
 @protocol NOZDecoder;

--- a/ZipUtilities/NOZUtils_Project.h
+++ b/ZipUtilities/NOZUtils_Project.h
@@ -25,7 +25,7 @@
 //  SOFTWARE.
 //
 
-#import "NOZUtils.h"
+#import <ZipUtilities/NOZUtils.h>
 
 #if __LP64__
 static const size_t NOZPointerByteSize = 8;

--- a/ZipUtilities/NOZZipEntry.h
+++ b/ZipUtilities/NOZZipEntry.h
@@ -27,7 +27,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZCompression.h"
+#import <ZipUtilities/NOZCompression.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ZipUtilities/NOZZipper.h
+++ b/ZipUtilities/NOZZipper.h
@@ -27,8 +27,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZUtils.h"
-#import "NOZZipEntry.h"
+#import <ZipUtilities/NOZUtils.h>
+#import <ZipUtilities/NOZZipEntry.h>
 
 @class NOZEncrytion;
 

--- a/ZipUtilities/NSData+NOZAdditions.h
+++ b/ZipUtilities/NSData+NOZAdditions.h
@@ -27,7 +27,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZCompression.h"
+#import <ZipUtilities/NOZCompression.h>
 
 @protocol NOZEncoder;
 @protocol NOZDecoder;

--- a/ZipUtilities/NSStream+NOZAdditions.h
+++ b/ZipUtilities/NSStream+NOZAdditions.h
@@ -27,7 +27,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "NOZCompression.h"
+#import <ZipUtilities/NOZCompression.h>
 
 @protocol NOZEncoder;
 @protocol NOZDecoder;

--- a/ZipUtilities/ZipUtilities.h
+++ b/ZipUtilities/ZipUtilities.h
@@ -25,18 +25,18 @@
 //  SOFTWARE.
 //
 
-#import "NOZCompress.h"
-#import "NOZCompression.h"
-#import "NOZCompressionLibrary.h"
-#import "NOZDecoder.h"
-#import "NOZDecompress.h"
-#import "NOZEncoder.h"
-#import "NOZError.h"
-#import "NOZSyncStepOperation.h"
-#import "NOZUnzipper.h"
-#import "NOZUtils.h"
-#import "NOZZipEntry.h"
-#import "NOZZipper.h"
+#import <ZipUtilities/NOZCompress.h>
+#import <ZipUtilities/NOZCompression.h>
+#import <ZipUtilities/NOZCompressionLibrary.h>
+#import <ZipUtilities/NOZDecoder.h>
+#import <ZipUtilities/NOZDecompress.h>
+#import <ZipUtilities/NOZEncoder.h>
+#import <ZipUtilities/NOZError.h>
+#import <ZipUtilities/NOZSyncStepOperation.h>
+#import <ZipUtilities/NOZUnzipper.h>
+#import <ZipUtilities/NOZUtils.h>
+#import <ZipUtilities/NOZZipEntry.h>
+#import <ZipUtilities/NOZZipper.h>
 
-#import "NSData+NOZAdditions.h"
-#import "NSStream+NOZAdditions.h"
+#import <ZipUtilities/NSData+NOZAdditions.h>
+#import <ZipUtilities/NSStream+NOZAdditions.h>


### PR DESCRIPTION
so that workspaces that have source which import ZipUtilities .h files
using framework style don't confuse the Xcode Build System when it sees
these same headers using infra-project style imports in the .h files.