### PR TITLE
zerowarnings: silence Xcode float-cast-to-int-vs-Sin64 + cleanup

### DIFF
--- a/ZipUtilities/NOZSyncStepOperation.m
+++ b/ZipUtilities/NOZSyncStepOperation.m
@@ -189,7 +189,7 @@
 
     SInt64 currentWeight = 0;
     for (NSUInteger iStep = 0; iStep < _stepCount; iStep++) {
-        currentWeight += _currentStepProgress[iStep] * _stepWeights[iStep];
+        currentWeight += (SInt64)_currentStepProgress[iStep] * _stepWeights[iStep];
         if (_currentStepProgress[iStep] < 0.f) {
             isIndeeterminate = YES;
         }


### PR DESCRIPTION
in Xcode 11.4, `updateProgres:forStep:` line 192 had the warning:

 implicit conversion turns floating-point number into integer:
 'float' to 'SInt64' (aka 'long long') [-Wfloat-conversion]