### PR TITLE
project+schemes: LastUpgradeCheck/Version = 1200

### DIFF
--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -1828,7 +1828,7 @@
 			attributes = {
 				CLASSPREFIX = NOZ;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = NSProgrammer;
 				TargetAttributes = {
 					1C6BF76F1B74086000969629 = {
@@ -2518,6 +2518,7 @@
 			buildSettings = {
 				EXECUTABLE_PREFIX = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2531,6 +2532,7 @@
 			buildSettings = {
 				EXECUTABLE_PREFIX = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2548,6 +2550,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2564,6 +2567,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2642,6 +2646,7 @@
 				INFOPLIST_FILE = ZipUtilities/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2667,6 +2672,7 @@
 				INFOPLIST_FILE = ZipUtilities/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2686,6 +2692,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2704,6 +2711,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				INFOPLIST_FILE = ZipUtilitiesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2814,6 +2822,7 @@
 				EXECUTABLE_PREFIX = "";
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2830,6 +2839,7 @@
 				EXECUTABLE_PREFIX = "";
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2846,6 +2856,7 @@
 				EXECUTABLE_PREFIX = "";
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2862,6 +2873,7 @@
 				EXECUTABLE_PREFIX = "";
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2940,6 +2952,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				INFOPLIST_FILE = ZipUtilitiesApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nsprogrammer.ZipUtilitiesApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2957,6 +2970,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				INFOPLIST_FILE = ZipUtilitiesApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nsprogrammer.ZipUtilitiesApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities Framework.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities Framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities OSX Framework.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities OSX Framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilities.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilitiesApp.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/ZipUtilitiesApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libZipUtilities-mac.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libZipUtilities-mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libbrotli-mac.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libbrotli-mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libbrotli.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libbrotli.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libzstd-mac.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libzstd-mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libzstd.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/libzstd.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/noz -Release.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/noz -Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ZipUtilities.xcodeproj/xcshareddata/xcschemes/noz.xcscheme
+++ b/ZipUtilities.xcodeproj/xcshareddata/xcschemes/noz.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
when upgrading to Xcode12, the only upgrade warnings are
w.r.t. IPHONEOS_DEPLOYMENT_TARGET

by setting the IPHONEOS_DEPLOYMENT_TARGET to 9.0 only for
`[sdk=iphonesimulator14.0]` (which means setting it only to
be used when building on Xcode12, which doesn't support any
simulators older than ios 9.0), ZipUtilities can continue to
quietly support hardware builds for older versions of
hardware whilst silencing the following:

 warning: The iOS Simulator deployment target
 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range
 of supported deployment target versions is 9.0 to 14.0.99.