### PR TITLE
Xcode 12.5: decline Xcode 12.5 min deploy target suggestions

### DIFF
--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -1828,7 +1828,7 @@
 			attributes = {
 				CLASSPREFIX = NOZ;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = NSProgrammer;
 				TargetAttributes = {
 					1C6BF76F1B74086000969629 = {


### PR DESCRIPTION
continue to allow these projects to be used by old SDKs, but silence
Xcode upgrade warnings.