### PR TITLE
zerowarnings: simulator: update to also work with Xcode 12.x where x > 0

### DIFF
--- a/ZipUtilities.xcodeproj/project.pbxproj
+++ b/ZipUtilities.xcodeproj/project.pbxproj
@@ -1828,7 +1828,7 @@
 			attributes = {
 				CLASSPREFIX = NOZ;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = NSProgrammer;
 				TargetAttributes = {
 					1C6BF76F1B74086000969629 = {
@@ -2646,7 +2646,7 @@
 				INFOPLIST_FILE = ZipUtilities/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.*]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2672,7 +2672,7 @@
 				INFOPLIST_FILE = ZipUtilities/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.*]" = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.NSProgrammer.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2856,7 +2856,7 @@
 				EXECUTABLE_PREFIX = "";
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.*]" = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2873,7 +2873,7 @@
 				EXECUTABLE_PREFIX = "";
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Extra";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.0]" = 9.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator14.*]" = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
when setting the value in the UI to "Simulator - iOS 14.5 SDK", the
value in the XML appears as `iphonesimulator14.5` .

by changing the value to `14.*`, the "Target Integrity" warning is
silenced for all versions of Xcode 12.x